### PR TITLE
Fixed some limpy larry stuff

### DIFF
--- a/entities/weapons/lava_fists.lua
+++ b/entities/weapons/lava_fists.lua
@@ -109,6 +109,7 @@ function SWEP:PrimaryAttack(NoForce)
 				end
 			elseif hook.Call( "Lava.PlayerPushPlayer", nil, self.Owner, Entity ) == nil then
 				Entity:SetVelocity(self.Owner:GetForward():SetZ(Entity:OnGround() and 0.2 or -0.2) * 1000)
+				Entity.m_LastShovedBy = self.Owner
 			end
 		end
 	end
@@ -119,7 +120,14 @@ function SWEP:Reload()
 	if not self.Owner:HasAbility("Limpy Larry") then return end
 	self.NextRagdollTime = self.NextRagdollTime or CurTime() + 1
 
-	if SERVER and self.NextRagdollTime < CurTime() then
+	local pos = self.Owner:GetBonePosition(self.Owner:LookupBone("ValveBiped.Bip01_Head1"))
+	local trace = util.TraceLine({
+		start = pos,
+		endpos = Vector(pos.x, pos.y, self.Owner:GetBonePosition(self.Owner:LookupBone("ValveBiped.Bip01_R_Foot")).z),
+		filter = player.GetAll()
+	})
+
+	if SERVER and self.NextRagdollTime < CurTime() and not trace.Hit then
 		Ragdoll.Enable(self.Owner)
 		self.Owner:Flashlight(false)
 		self.Owner.m_NextRagdollifcationTime = CurTime() + 1

--- a/gamemode/core/abilities/limpylarry/ragdollification.lua
+++ b/gamemode/core/abilities/limpylarry/ragdollification.lua
@@ -32,6 +32,18 @@ function Ragdoll.Enable( Player )
 			ragdoll:Remove()
 		end
 	end)
+	for i = 0, Player:GetBoneCount() - 1 do
+		local bone = ragdoll:GetPhysicsObjectNum( i )
+		
+		if IsValid( bone ) then
+			local pos, ang = Player:GetBonePosition( ragdoll:TranslatePhysBoneToBone( i ) )
+			
+			if pos and ang then
+				bone:SetPos( pos )
+				bone:SetAngles( ang )
+			end
+		end
+	end
 	Player:SetParent( ragdoll )
 
 	local velocity = Player:GetVelocity()

--- a/gamemode/core/rounds/sv_rounds.lua
+++ b/gamemode/core/rounds/sv_rounds.lua
@@ -55,8 +55,9 @@ function Rounds.Start()
 		if not Player:Alive() then
 			Player:Spawn()
 			Player:SetObserverMode( OBS_MODE_NONE )
-		elseif Player:Health() ~= 100 then
+		elseif Player:Health() ~= 100 or ( Player.m_Ragdoll and Player.m_RagdollData.Health ~= 100 ) then
 			Player:SetHealth( Player:HasAbility("Skippy Feet") and 35 or 100 )
+			if Player.m_Ragdoll then Player.m_RagdollData.Health = 100 end
 		end
 		if Player:GetActiveWeapon():IsValid() and Player:GetActiveWeapon():GetClass() == "lava_fists" then
 			Player:GetActiveWeapon():SetEggs( 6 )


### PR DESCRIPTION
- Ragdoll wil now spawn in same position as the players animation was.
- Fixed exploit with ragdoll being able to spawn inside roof/ceiling.
- Fixed bug where health would not reset to 100 on round start when
player is in ragdoll mode.
- (line 112 in lava_fist.lua is to not have any conflicts with the 'Kill
credit' pull request)